### PR TITLE
change home page to github and add doc_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About gitpython
 ===============
 
-Home: http://gitorious.org/projects/git-python/
+Home: https://github.com/gitpython-developers/GitPython
 
 Package license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,11 +32,12 @@ test:
     - git.repo
 
 about:
-  home: http://gitorious.org/projects/git-python/
+  home: https://github.com/gitpython-developers/GitPython
   license: BSD 3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: 'Python Git Library'
+  doc_url:  http://gitpython.readthedocs.org
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The home page, http://gitorious.org/projects/git-python/, doesn't seem to be working.
