### PR TITLE
Fix "No module named 'gitdb.utils.compat'" error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
 test:
   requires:
     - git
+    - pip
   imports:
     - git
     - git.index
@@ -31,6 +32,8 @@ test:
     - git.objects.submodule
     - git.refs
     - git.repo
+  commands:
+    - pip check
 
 about:
   home: https://github.com/gitpython-developers/GitPython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9c2398ffc3dcb3c40b27324b316f08a4f93ad646d5a6328cafbb871aa79f5e42
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -19,7 +19,7 @@ requirements:
     - pip
   run:
     - python >=3
-    - gitdb2
+    - gitdb2 <=3.0.0
 
 test:
   requires:


### PR DESCRIPTION
This commit pins gitdb2 to 3.0.0 since it appears that version 3.0.2
has some braking changes.

```
(gitpython-test) λ $ py
Python 3.6.7 | packaged by conda-forge | (default, Nov  6 2019, 16:19:42) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import git
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/igor/w/meta/envs/gitpython-test/lib/python3.6/site-packages/git/__init__.py", line 38, in <module>
    from git.exc import *                       # @NoMove @IgnorePep8
  File "/home/igor/w/meta/envs/gitpython-test/lib/python3.6/site-packages/git/exc.py", line 9, in <module>
    from git.compat import UnicodeMixin, safe_decode, string_types
  File "/home/igor/w/meta/envs/gitpython-test/lib/python3.6/site-packages/git/compat.py", line 16, in <module>
    from gitdb.utils.compat import (
ModuleNotFoundError: No module named 'gitdb.utils.compat'
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
